### PR TITLE
Update FormType.php.twig

### DIFF
--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -71,7 +71,7 @@ class {{ form_class }} extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return '{{ form_type_name }}';
     }


### PR DESCRIPTION
Altered form generator template to follow the new Symfony 3 naming process for block names passed into forms.
public function getName() --> become --> public function getBlockPrefix()